### PR TITLE
Generate proper session IDs

### DIFF
--- a/src/PSR7Bridge.php
+++ b/src/PSR7Bridge.php
@@ -93,23 +93,8 @@ class PSR7Bridge
     /**
      * @return string
      */
-    private function generateSessionId():string
+    private function generateSessionId(): string
     {
-        $entropy = '';
-
-        $entropy .= uniqid(mt_rand(), true);
-        $entropy .= microtime(true);
-
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            $entropy .= openssl_random_pseudo_bytes(32, $strong);
-        }
-
-        if (function_exists('mcrypt_create_iv')) {
-            $entropy .= mcrypt_create_iv(32, MCRYPT_DEV_URANDOM);
-        }
-
-        $hash = hash('whirlpool', $entropy);
-
-        return $hash;
+        return bin2hex(random_bytes(32));
     }
 }


### PR DESCRIPTION
The project already requires PHP 7, so using `random_bytes()` directly is fine. The previous version is horrofically insecure if neither `openssl` nor `mcrypt` are available or if `openssl` is available but returns non-strong entropy.